### PR TITLE
Reducers are not mapped after persist is rehydrated from storage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shoutem/redux-composers",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Reducers you can use for composing reducer hierarchy like with combineReducers from redux",
   "main": "lib/index.js",
   "files": [

--- a/src/mapReducers.js
+++ b/src/mapReducers.js
@@ -130,7 +130,7 @@ export function mapReducerFactory(keySelector, reducerFactory) {
       return calculateNewStateForAllKeys(
         state,
         action,
-        (stateKey) => reducers[stateKey]
+        (stateKey) => reducers[stateKey] || reducerFactory(stateKey)
       );
     }
 


### PR DESCRIPTION
This can be only reproducible when combined with redux persist and you are targeting all reducers (key = TARAGET_ALL) in the mapped reducer.